### PR TITLE
Update workshop reporting template with planning issue link

### DIFF
--- a/.github/ISSUE_TEMPLATE/nasa-openscapes-workshop-reporting-template.md
+++ b/.github/ISSUE_TEMPLATE/nasa-openscapes-workshop-reporting-template.md
@@ -10,7 +10,7 @@ assignees: ''
 <!--
 **Purpose:** reporting on workshops that use the Openscapes 2i2c Hub  
 **Outcomes:** mentors, infrastructure providers, workshop supporters can copy / remix this information in formal or informal reports. Openscapes can publish as a short blog post on [nasa-openscapes.github.io/news](https://nasa-openscapes.github.io/news) and link that from home page Recent workshops for visibility.  
-**Process:** following completion of a workshop, the point of contact opens an issue using this template and fills in the elements.
+**Process:** following completion of a workshop, the point of contact opens an issue using this template and fills in the elements. When you open this issue, please link to (in the "Other Links" section), and then close the planning issue originally opened for the workshop.
 
 Please provide as much of the following information as you can, and feel free to expand on any sections.
 -->
@@ -38,8 +38,8 @@ We presented the following notebooks from the _____ [insert source repository or
 
 ### Other links
 
+Here is the planning issue in this repo for the workshop: _____ [ example: #154]
 Here is the 2i2c request for the workshop: _____ [ example: https://github.com/2i2c-org/infrastructure/issues/6645]
-
 
 ### Citing Openscapes JupyterHub Access
 


### PR DESCRIPTION
Added a note to link and close the planning issue after the workshop.

The `closes #x` or `fixes #x` magic syntax doesn't work in issues, only PRs (which makes sense, because PRs make commits when they are merged), so I just added instructions to link to and close the issue.

We could also add a formal relationship between the two issues by designating the original planning issue as the parent, and the reporting issue as the sub-issue: 

<img width="399" height="223" alt="image" src="https://github.com/user-attachments/assets/f25ba7e6-bc00-4809-8116-024e2a16d58b" />

