### PR TITLE
Workshop issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/nasa-openscapes-workshop-template-form.yml
+++ b/.github/ISSUE_TEMPLATE/nasa-openscapes-workshop-template-form.yml
@@ -18,7 +18,7 @@ body:
     id: workshop-start-date
     attributes:
       label: Workshop Start Date
-      description: Please provide the start date of your wor.
+      description: Please provide the start date of your workshop.
       placeholder: YYYY-MM-DD
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/nasa-openscapes-workshop-template.md
+++ b/.github/ISSUE_TEMPLATE/nasa-openscapes-workshop-template.md
@@ -22,7 +22,7 @@ Short description is fine. Please include a link to the workshop website if you 
 **Event Start Date/Time	and Event End Date/Time**
 
 **Reset Date**
-By default the password will be reset and participants' home direrectories erased seven days after the workshop ends. 
+By default the password will be reset and participants' home directories erased seven days after the workshop ends. 
 If you want the participants to have more or less access than the default of seven days, please specify here.
 
 **Number of Participants**


### PR DESCRIPTION
I've added two templates here - one is a direct copy from the NMFS-Openscapes form, the other is a reworking of it to use the newer GitHub [issue form template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms).

I think by using the newer forms syntax it makes the form both easier to fill in, and also possibly easier to parse if we want to pull in workshop metadata from the issues at some point in the future (I'm thinking about how to reduce duplication that we currently have with the workshop planning spreadhseet).

To really see what they both look like, I think we might need to merge so we can try them out...

Closes #167 